### PR TITLE
Fix the Sonar warning suppression in ClientPoller

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/poller/ClientPoller.java
+++ b/src/main/java/org/kiwiproject/dropwizard/poller/ClientPoller.java
@@ -317,7 +317,7 @@ public class ClientPoller {
         LOG.trace("{} - Poll time: {} millis", name, elapsed);
     }
 
-    @SuppressWarnings({"squid:51612", "Convert2MethodRef"})
+    @SuppressWarnings({"java:S1612", "Convert2MethodRef"})
     private Response executePollRequest() {
         statistics().incrementCount();
         try {


### PR DESCRIPTION
It should be S1612 (with a letter "S") not 51612 (with a number 5)