### PR TITLE
Update parent POM and kiwi dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0</version>
     </parent>
 
     <artifactId>dropwizard-client-poller</artifactId>
@@ -32,8 +32,8 @@
         <hibernate-validator.version>6.1.6.Final</hibernate-validator.version>
         <jackson.version>2.10.5</jackson.version>
         <jersey.version>2.32</jersey.version>
-        <kiwi.version>0.15.0</kiwi.version>
-        <metrics-healthchecks-severity.version>0.12.1</metrics-healthchecks-severity.version>
+        <kiwi.version>0.16.0</kiwi.version>
+        <metrics-healthchecks-severity.version>0.13.0</metrics-healthchecks-severity.version>
         <metrics-jetty9>4.1.14</metrics-jetty9>
         <metrics-servlets.version>4.1.14</metrics-servlets.version>
 
@@ -42,7 +42,7 @@
         <!-- Versions for optional dependencies -->
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>0.10.0</kiwi-test.version>
+        <kiwi-test.version>0.11.0</kiwi-test.version>
 
         <!-- Versions for plugins -->
 


### PR DESCRIPTION
* Bump kiwi-parent to 0.4.0
* Bump kiwi to 0.16.0
* Bump kiwi-test to 0.11.0
* Bump metrics-healthchecks-severity to 0.13.0

Fixes #25
Fixes #26
Fixes #27
Fixes #28