### PR TITLE
Re-interrupt current thread for InterruptedExceptions in ClientPoller

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
@@ -613,7 +613,7 @@ class ClientPollerTest {
         void testCannotStart_WithoutIntervalType() {
             assertThatThrownBy(() -> poller.start(null))
                     .isExactlyInstanceOf(IllegalStateException.class)
-                    .hasMessage("intervalType must be specified to start polling");
+                    .hasMessage("delayType must be specified to start polling");
         }
 
         @Test


### PR DESCRIPTION
* In executePollRequest and shutdownQuietly, if the Exception in the
  catch block is an InterruptedException, then re-interrupt the current
  thread. See Sonar rule java:S2142 for the full explanation.

Misc:
* Rename start(DelayType) method arg from intervalType to delayType
* Change the Supplier<Response> from a lambda to a method reference;
  not sure why we previously suppressed this. Also renamed var from
  asyncSupplier to responseSupplier. The actual Supplier<Response> is
  synchronous, and is being given to the doAsync method for async
  execution. So, the name was misleading.
* Add additional javadocs
* Suppress incorrect warnings about various fields not being nullable
  in validateInternalState method. They CAN be null if someone passes
  null values into the builder.