### PR TITLE
Update parent POM and BOM for JDK 17 and major library updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ '11', '17', '20' ]
+        java_version: [ '17', '20' ]
     steps:
       # Check out the project
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
       # Cache all the things
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -54,16 +54,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V compile
 
-      # Run tests when Java version > 11 (Sonar runs tests and analysis on JDK 11)
+      # Run tests when Java version > 17 (Sonar runs tests and analysis on JDK 17)
       - name: Run tests
-        if: ${{ matrix.java_version != '11' }}
+        if: ${{ matrix.java_version != '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V verify
 
-      # Run Sonar Analysis (on Java version 11 only)
+      # Run Sonar Analysis (on Java version 17 only)
       - name: Analyze with SonarCloud
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Java 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 17
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>2.0.20</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>dropwizard-client-poller</artifactId>
-    <version>1.0.14-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -28,12 +28,12 @@
 
     <properties>
         <!-- Versions for required dependencies -->
-        <kiwi.version>2.7.0</kiwi.version>
-        <kiwi-bom.version>1.1.1</kiwi-bom.version>
-        <metrics-healthchecks-severity.version>1.0.13</metrics-healthchecks-severity.version>
+        <kiwi.version>3.0.0</kiwi.version>
+        <kiwi-bom.version>2.0.0</kiwi-bom.version>
+        <metrics-healthchecks-severity.version>2.0.0</metrics-healthchecks-severity.version>
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>2.4.0</kiwi-test.version>
+        <kiwi-test.version>3.0.0</kiwi-test.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_dropwizard-client-poller</sonar.projectKey>

--- a/src/main/java/org/kiwiproject/dropwizard/poller/ClientPoller.java
+++ b/src/main/java/org/kiwiproject/dropwizard/poller/ClientPoller.java
@@ -11,7 +11,10 @@ import static org.kiwiproject.concurrent.Async.withMaxTimeout;
 import static org.kiwiproject.jaxrs.KiwiResponses.closeQuietly;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
+import jakarta.ws.rs.client.SyncInvoker;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,9 +25,6 @@ import org.kiwiproject.dropwizard.poller.health.ClientPollerHealthChecks;
 import org.kiwiproject.dropwizard.poller.metrics.ClientPollerStatistics;
 import org.kiwiproject.dropwizard.poller.metrics.DefaultClientPollerStatistics;
 
-import javax.ws.rs.client.SyncInvoker;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -97,7 +97,7 @@ public class ClientPoller {
      * The URI the poller is polling. This will be set if the {@link SyncInvoker} provided is an instance of
      * {@link PollerSyncInvokerWrapper}
      * <p>
-     * NOTE: only used for logging purposes. It will be overwritten so we should not ever manually set it.
+     * NOTE: only used for logging purposes. It will be overwritten, so we should not ever manually set it.
      */
     private URI uri;
 
@@ -173,7 +173,7 @@ public class ClientPoller {
     private final long executionInterval;
 
     /**
-     * The executor the poller should use to scheduled a fixed-rate or fixed-delay poll. <em>Required.</em>
+     * The executor the poller should use to schedule a fixed-rate or fixed-delay poll. <em>Required.</em>
      */
     private final ScheduledExecutorService executor;
 
@@ -286,13 +286,11 @@ public class ClientPoller {
     }
 
     /**
-     * @implNote We could replace this validation with Lombok's {@code @NonNull} annotation. However we would
+     * @implNote We could replace this validation with Lombok's {@code @NonNull} annotation. However, we would
      * then get {@link NullPointerException} when calling the build method on the builder, instead of
      * the {@link IllegalStateException} that is thrown here. It seems throwing an {@link IllegalStateException}
      * is more appropriate than NPE in this case, or at least more clear.
      */
-    // Following suppression is because some of the fields CAN be null if explicitly nullified when building a poller
-    @SuppressWarnings("ConstantConditions")
     private void validateInternalState() {
         checkState(nonNull(supplier), "supplier cannot be null");
         checkState(nonNull(consumerType), "consumerType cannot be null");
@@ -374,8 +372,8 @@ public class ClientPoller {
     }
 
     private void updateUri(SyncInvoker invoker) {
-        if (invoker instanceof PollerSyncInvokerWrapper) {
-            String currentUri = ((PollerSyncInvokerWrapper) invoker).getUri();
+        if (invoker instanceof PollerSyncInvokerWrapper wrapper) {
+            String currentUri = wrapper.getUri();
             uri = UriBuilder.fromPath(currentUri).build();
         }
     }

--- a/src/main/java/org/kiwiproject/dropwizard/poller/PollerSyncInvokerWrapper.java
+++ b/src/main/java/org/kiwiproject/dropwizard/poller/PollerSyncInvokerWrapper.java
@@ -1,11 +1,10 @@
 package org.kiwiproject.dropwizard.poller;
 
+import jakarta.ws.rs.client.SyncInvoker;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Delegate;
-
-import javax.ws.rs.client.SyncInvoker;
 
 /**
  * A wrapper for a {@link SyncInvoker} in order for the poller to have access to the original URI for logging and debugging

--- a/src/main/java/org/kiwiproject/dropwizard/poller/config/PollerHealthCheckConfig.java
+++ b/src/main/java/org/kiwiproject/dropwizard/poller/config/PollerHealthCheckConfig.java
@@ -10,14 +10,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.MaxDuration;
 import io.dropwizard.validation.MinDuration;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.Builder;
 import lombok.Value;
 import org.kiwiproject.dropwizard.poller.health.ClientPollerLatencyBasedHealthCheck;
 import org.kiwiproject.dropwizard.poller.health.ClientPollerMissedPollHealthCheck;
 import org.kiwiproject.dropwizard.poller.health.ClientPollerTimeBasedHealthCheck;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -67,7 +67,7 @@ public class PollerHealthCheckConfig {
      * <p>
      * Default: {@link ClientPollerMissedPollHealthCheck#DEFAULT_MISSING_POLL_MULTIPLIER}
      * <p>
-     * For example, at a value of 10, and assuming a 2 second interval between polls, then polling will be
+     * For example, at a value of 10, and assuming a 2-second interval between polls, then polling will be
      * reported unhealthy if the last poll attempt is more than 20 seconds ago (10 * 2).
      *
      * @see ClientPollerMissedPollHealthCheck

--- a/src/main/java/org/kiwiproject/dropwizard/poller/health/ClientPollerHealthChecks.java
+++ b/src/main/java/org/kiwiproject/dropwizard/poller/health/ClientPollerHealthChecks.java
@@ -1,13 +1,12 @@
 package org.kiwiproject.dropwizard.poller.health;
 
-import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.kiwiproject.base.KiwiStrings.format;
 import static org.kiwiproject.metrics.health.HealthCheckResults.newUnhealthyResultBuilder;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheck.Result;
 import com.google.common.annotations.VisibleForTesting;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.experimental.UtilityClass;
@@ -103,7 +102,7 @@ public class ClientPollerHealthChecks {
                                    Object... args) {
         return newUnhealthyResultBuilder(severity)
                 .withMessage(messageTemplate, args)
-                .withDetail(FAILURE_DETAILS_KEY, statistics.recentFailureDetails().collect(toUnmodifiableList()))
+                .withDetail(FAILURE_DETAILS_KEY, statistics.recentFailureDetails().toList())
                 .build();
     }
 

--- a/src/main/java/org/kiwiproject/dropwizard/poller/metrics/DefaultClientPollerStatistics.java
+++ b/src/main/java/org/kiwiproject/dropwizard/poller/metrics/DefaultClientPollerStatistics.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
  * <p>
  * This implementation is <em>effectively thread-safe</em> if each {@link ClientPoller} is using its own
  * {@link ClientPollerStatistics} instance. This is true because a poller instance is scheduled to execute at a
- * fixed-rate and so it sleeps, executes, sleeps, executes, etc. Thus there is only <em>one</em> poller instance acting
+ * fixed-rate and so it sleeps, executes, sleeps, executes, etc. Thus, there is only <em>one</em> poller instance acting
  * on its {@link ClientPollerStatistics} instance at any given time.
  */
 @Slf4j
@@ -117,7 +117,7 @@ public class DefaultClientPollerStatistics implements ClientPollerStatistics {
     }
 
     /**
-     * See section "Cumulative moving average" (CMA) on Moving Average page: https://en.wikipedia.org/wiki/Moving_average
+     * See section "Cumulative moving average" (CMA) on <a href="https://en.wikipedia.org/wiki/Moving_average">Moving Average page</a>
      */
     @Override
     public void addPollLatencyMeasurement(long latencyInMillis) {
@@ -225,7 +225,7 @@ public class DefaultClientPollerStatistics implements ClientPollerStatistics {
 
     @VisibleForTesting
     int numberOfFailureDetails() {
-        return (recentFailures.size() > FAILURE_DETAIL_LIMIT) ? FAILURE_DETAIL_LIMIT : recentFailures.size();
+        return Math.min(recentFailures.size(), FAILURE_DETAIL_LIMIT);
     }
 
     @Override

--- a/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
@@ -21,7 +21,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.codahale.metrics.health.HealthCheckRegistry;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.client.SyncInvoker;
+import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
@@ -40,9 +43,6 @@ import org.kiwiproject.dropwizard.poller.health.ClientPollerTimeBasedHealthCheck
 import org.kiwiproject.dropwizard.poller.metrics.ClientPollerStatistics;
 import org.kiwiproject.dropwizard.poller.metrics.DefaultClientPollerStatistics;
 
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.client.SyncInvoker;
-import javax.ws.rs.core.Response;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;

--- a/src/test/java/org/kiwiproject/dropwizard/poller/config/PollerHealthCheckConfigTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/config/PollerHealthCheckConfigTest.java
@@ -5,7 +5,7 @@ import static org.kiwiproject.dropwizard.poller.health.ClientPollerTimeBasedHeal
 import static org.kiwiproject.dropwizard.poller.health.ClientPollerTimeBasedHealthCheck.DEFAULT_TIME_WINDOW_MINUTES;
 import static org.kiwiproject.test.validation.ValidationTestHelper.assertPropertyViolations;
 
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Configuration;
 import io.dropwizard.util.Duration;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/test/java/org/kiwiproject/dropwizard/poller/metrics/DefaultClientPollerStatisticsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/metrics/DefaultClientPollerStatisticsTest.java
@@ -114,6 +114,7 @@ class DefaultClientPollerStatisticsTest {
         assertThat(stats.recentFailureTimesInMillis().count()).isEqualTo(stats.maxRecentFailureTimes());
     }
 
+    @SuppressWarnings({"EmptyMethod", "unused"})
     private void noop(long value) {
     }
 


### PR DESCRIPTION
* Bump version to 2.0.0-SNAPSHOT
* Bump kiwi-parent from 2.0.20 to 3.0.1
* Bump kiwi-bom from 1.1.1 to 2.0.0
* Bump kiwi libraries to next major version
* Update build for JDK 17 and 20
* Update CodeQL workflow to use JDK 17
* Fix Dropwizard package changes
* Refactor from javax to jakarta namespace for Jakarta EE 9

Misc cleanup:

* Fix a few grammatical errors
* Sonar JDK 17: replace collectors with toList()
* Fix javadoc: make into HTML link
* Use Math#min instead of ternary in DefaultClientPollerStatistics