### PR TITLE
Make Sonar happy by covering the "new" lines of code in ClientPoller

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/poller/ClientPoller.java
+++ b/src/main/java/org/kiwiproject/dropwizard/poller/ClientPoller.java
@@ -371,11 +371,13 @@ public class ClientPoller {
         }
     }
 
-    private void updateUri(SyncInvoker invoker) {
+    @VisibleForTesting
+    URI updateUri(SyncInvoker invoker) {
         if (invoker instanceof PollerSyncInvokerWrapper wrapper) {
             String currentUri = wrapper.getUri();
             uri = UriBuilder.fromPath(currentUri).build();
         }
+        return uri;
     }
 
     private String uriOrDefault() {

--- a/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
@@ -386,6 +386,43 @@ class ClientPollerTest {
     class DifficultToTestMethods {
 
         @Nested
+        class UpdateUri {
+
+            private ClientPoller poller;
+            private PollerSyncInvokerWrapper wrappedInvoker;
+
+            @BeforeEach
+            void setUp() {
+                wrappedInvoker = PollerSyncInvokerWrapper.builder()
+                        .delegateSyncInvoker(invoker)
+                        .uri("https://localhost:10042")
+                        .build();
+
+                poller = ClientPoller.builder()
+                        .consumer(consumer)
+                        .supplier(() -> wrappedInvoker)
+                        .executor(executor)
+                        .executionInterval(intervalInMillis)
+                        .build();
+            }
+
+            @Test
+            void shouldUpdateUri_WhenGivenWrapper() {
+                var uri = poller.updateUri(wrappedInvoker);
+                assertThat(uri)
+                        .hasScheme("https")
+                        .hasAuthority("localhost:10042")
+                        .hasNoQuery();
+            }
+
+            @Test
+            void shouldNotUpdateUri_WhenGivenArgument_ThatIsNotWrapper() {
+                var uri = poller.updateUri(invoker);
+                assertThat(uri).isNull();
+            }
+        }
+
+        @Nested
         class WaitForCompletion {
 
             private ClientPoller syncPoller;


### PR DESCRIPTION
* Add tests for ClientPoller#updateUri
* Make updateUri package-private and annotate with VisibleForTesting
* Change updateUri to return the current value of the uri field to help test whether the value was set