### PR TITLE
Sonar cleanup

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
@@ -165,7 +165,7 @@ class ClientPollerTest {
 
     @Test
     void testPollersGetADefault_Name_IfNotSupplied() {
-        var poller = ClientPoller.builder()
+        poller = ClientPoller.builder()
                 .consumer(consumer)
                 .supplier(() -> invoker)
                 .executor(executor)
@@ -881,7 +881,7 @@ class ClientPollerTest {
                     .build();
 
             try {
-                when(invoker.get()).thenAnswer(answersWithDelay(500L, (invocationOnMock) -> response));
+                when(invoker.get()).thenAnswer(answersWithDelay(500L, invocationOnMock -> response));
 
                 var startTime = System.currentTimeMillis();
                 startPollerAndStopOnceConditionIsMet(slowPoller, () -> slowPoller.statistics().failureCount() > 0);

--- a/src/test/java/org/kiwiproject/dropwizard/poller/config/PollerHealthCheckConfigTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/config/PollerHealthCheckConfigTest.java
@@ -86,9 +86,9 @@ class PollerHealthCheckConfigTest {
             var path = Paths.get("PollerHealthCheckConfigTest", configFileName);
 
             try {
-                var config = DropwizardConfigurations.newConfiguration(SampleConfig.class, path);
+                var sampleConfig = DropwizardConfigurations.newConfiguration(SampleConfig.class, path);
 
-                return config.getHealthCheckConfig();
+                return sampleConfig.getHealthCheckConfig();
             } catch (Exception e) {
                 throw new AssertionFailedError("Error de-serializing config at path: " + path, e);
             }

--- a/src/test/java/org/kiwiproject/dropwizard/poller/health/ClientPollerHealthChecksTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/health/ClientPollerHealthChecksTest.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.dropwizard.poller.health;
 
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kiwiproject.base.KiwiStrings.f;
 import static org.mockito.ArgumentMatchers.eq;
@@ -76,7 +75,7 @@ class ClientPollerHealthChecksTest {
 
             var failedResult = ClientPollerHealthChecks.unhealthy(stats, "testMessage %s %d", "foo", 42);
 
-            List<Map<String, Object>> failureDetails = stats.recentFailureDetails().collect(toList());
+            List<Map<String, Object>> failureDetails = stats.recentFailureDetails().toList();
 
             assertThat(failedResult.isHealthy()).isFalse();
             assertThat(failedResult.getMessage()).isEqualTo("testMessage foo 42");

--- a/src/test/java/org/kiwiproject/dropwizard/poller/health/ClientPollerTimeBasedHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/health/ClientPollerTimeBasedHealthCheckTest.java
@@ -224,13 +224,13 @@ class ClientPollerTimeBasedHealthCheckTest {
         @Test
         void whenFailureCount_IsEqualToThresholdWithMultiplier() {
             assertUnhealthyWithComputedFailureCount("WARN",
-                    (maxPollFailuresAllowed, severityThresholdMultiplier) -> severityThresholdMultiplier * maxPollFailuresAllowed);
+                    (maxPollFailuresAllowed, theSeverityThresholdMultiplier) -> theSeverityThresholdMultiplier * maxPollFailuresAllowed);
         }
 
         @Test
         void whenFailureCount_IsOneMoreThanThresholdWithMultiplier() {
             assertUnhealthyWithComputedFailureCount("CRITICAL",
-                    (maxPollFailuresAllowed, severityThresholdMultiplier) -> 1 + (severityThresholdMultiplier * maxPollFailuresAllowed));
+                    (maxPollFailuresAllowed, theSeverityThresholdMultiplier) -> 1 + (theSeverityThresholdMultiplier * maxPollFailuresAllowed));
         }
 
         private void assertUnhealthyWithComputedFailureCount(String expectedSeverity, BiFunction<Long, Integer, Long> failureCountFn) {

--- a/src/test/java/org/kiwiproject/dropwizard/poller/metrics/DefaultClientPollerStatisticsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/metrics/DefaultClientPollerStatisticsTest.java
@@ -1,5 +1,6 @@
 package org.kiwiproject.dropwizard.poller.metrics;
 
+import static java.util.Comparator.reverseOrder;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
@@ -51,8 +52,8 @@ class DefaultClientPollerStatisticsTest {
         softly.assertThat(stats.lastSkipTimeInMillis()).isEmpty();
         softly.assertThat(stats.failureCount()).isZero();
         softly.assertThat(stats.lastFailureTimeInMillis()).isEmpty();
-        softly.assertThat(stats.recentFailureTimesInMillis().collect(toList())).isEmpty();
-        softly.assertThat(stats.recentFailureDetails().collect(toList())).isEmpty();
+        softly.assertThat(stats.recentFailureTimesInMillis().toList()).isEmpty();
+        softly.assertThat(stats.recentFailureDetails().toList()).isEmpty();
     }
 
     @Test
@@ -159,8 +160,7 @@ class DefaultClientPollerStatisticsTest {
 
         softly.assertThat(failureDetails).hasSize(expectedNumberOfFailureDetails);
 
-        List<Long> recentFailureTimes = stats.recentFailureTimesInMillis().collect(toList());
-        Collections.reverse(recentFailureTimes);
+        List<Long> recentFailureTimes = stats.recentFailureTimesInMillis().sorted(reverseOrder()).toList();
 
         // noinspection UnstableApiUsage
         Streams.zip(failureDetails.stream(), recentFailureTimes.stream(),
@@ -181,7 +181,7 @@ class DefaultClientPollerStatisticsTest {
 
         softly.assertThat(stats.failureCount()).isEqualTo(4);
 
-        List<Map<String, Object>> failureDetails = stats.recentFailureDetails().collect(toList());
+        List<Map<String, Object>> failureDetails = stats.recentFailureDetails().toList();
 
         softly.assertThat(failureDetails).hasSize(4);
     }


### PR DESCRIPTION
Fixes issues flagged by Sonar in ClientPollerTest, PollerHealthCheckConfigTest, ClientPollerHealthChecksTest, ClientPollerTimeBasedHealthCheckTest, and DefaultClientPollerStatisticsTest:

Sonar issues fixed:

* Local variables should not shadow class fields (java:S1117)
* Parentheses should be removed from a single lambda parameter when its type is inferred java:S1611
* "Stream.toList()" method should be used instead of "collectors" when unmodifiable list needed java:S6204