### PR TITLE
Misc Sonar and grammar cleanup

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/poller/ClientPoller.java
+++ b/src/main/java/org/kiwiproject/dropwizard/poller/ClientPoller.java
@@ -41,7 +41,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Polls a specified HTTP(S) endpoint either synchronously or asynchronously using a JAX-RS {@link SyncInvoker}.
+ * Polls a specified HTTP (or HTTPS) endpoint either synchronously or asynchronously using a JAX-RS {@link SyncInvoker}.
  */
 @Builder
 @Slf4j
@@ -132,14 +132,14 @@ public class ClientPoller {
     private final Long syncConsumerTimeout = DEFAULT_SYNC_RESPONSE_CONSUMER_TIMEOUT;
 
     /**
-     * The unit of the synchronous response consumer time out value.
+     * The unit of the synchronous response consumer timeout value.
      */
     @Getter(AccessLevel.PACKAGE)
     @Builder.Default
     private final TimeUnit syncConsumerTimeoutUnit = DEFAULT_SYNC_RESPONSE_CONSUMER_TIMEOUT_UNIT;
 
     /**
-     * The value after which the {@link #supplier} will time out, e.g. if a poll is taking a very long time.
+     * The value after which the {@link #supplier} will time out, e.g., if a poll is taking a very long time.
      */
     @Getter(AccessLevel.PACKAGE)
     @Builder.Default
@@ -289,7 +289,7 @@ public class ClientPoller {
      * @implNote We could replace this validation with Lombok's {@code @NonNull} annotation. However, we would
      * then get {@link NullPointerException} when calling the build method on the builder, instead of
      * the {@link IllegalStateException} that is thrown here. It seems throwing an {@link IllegalStateException}
-     * is more appropriate than NPE in this case, or at least more clear.
+     * is more appropriate than NPE in this case, or at least clearer.
      */
     private void validateInternalState() {
         checkState(nonNull(supplier), "supplier cannot be null");

--- a/src/main/java/org/kiwiproject/dropwizard/poller/health/ClientPollerMissedPollHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/poller/health/ClientPollerMissedPollHealthCheck.java
@@ -4,7 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 import static org.kiwiproject.metrics.health.HealthCheckResults.newHealthyResult;
-import static org.kiwiproject.time.KiwiDurationFormatters.formatDurationWords;
+import static org.kiwiproject.time.KiwiDurationFormatters.formatMillisecondDurationWords;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.google.common.annotations.VisibleForTesting;
@@ -57,9 +57,9 @@ public class ClientPollerMissedPollHealthCheck extends HealthCheck {
 
         LOG.info("For poller with execution interval {} and missing poll multiplier {}," +
                         " using {} as the missing poll alert threshold, after which we will report the poller unhealthy",
-                formatDurationWords(poller.getExecutionInterval()),
+                formatMillisecondDurationWords(poller.getExecutionInterval()),
                 this.missingPollMultiplier,
-                formatDurationWords(missingPollAlertThresholdMillis));
+                formatMillisecondDurationWords(missingPollAlertThresholdMillis));
     }
 
     /**

--- a/src/main/java/org/kiwiproject/dropwizard/poller/health/ClientPollerTimeBasedHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/poller/health/ClientPollerTimeBasedHealthCheck.java
@@ -24,7 +24,7 @@ import java.time.temporal.TemporalUnit;
 public class ClientPollerTimeBasedHealthCheck extends HealthCheck {
 
     /**
-     * Defines the default threshold for failed polls within time window as 2%
+     * Defines the default threshold for failed polls within the time window as 2%
      */
     public static final int DEFAULT_FAILED_POLLS_UNHEALTHY_THRESHOLD_PERCENT = 2;
 
@@ -285,8 +285,8 @@ public class ClientPollerTimeBasedHealthCheck extends HealthCheck {
     }
 
     /**
-     * @implNote The first three arguments MUST be in the same units, e.g. all milliseconds. The threshold argument
-     * MUST be a decimal value, e.g. 0.03 (for 3%)
+     * @implNote The first three arguments MUST be in the same units, e.g., all milliseconds. The threshold argument
+     * MUST be a decimal value, e.g., 0.03 (for 3%)
      */
     @VisibleForTesting
     static long calculateMaxPollFailuresAllowed(long timeWindow,

--- a/src/main/java/org/kiwiproject/dropwizard/poller/metrics/ClientPollerStatistics.java
+++ b/src/main/java/org/kiwiproject/dropwizard/poller/metrics/ClientPollerStatistics.java
@@ -45,7 +45,7 @@ public interface ClientPollerStatistics {
     void incrementSuccessCount();
 
     /**
-     * Increment the number of times polling was skipped.
+     * Increment the number of times that polling was skipped.
      */
     void incrementSkipCount();
 

--- a/src/main/java/org/kiwiproject/dropwizard/poller/metrics/DefaultClientPollerStatistics.java
+++ b/src/main/java/org/kiwiproject/dropwizard/poller/metrics/DefaultClientPollerStatistics.java
@@ -68,7 +68,7 @@ public class DefaultClientPollerStatistics implements ClientPollerStatistics {
     }
 
     /**
-     * @implNote This is left public for now, so we can expose it with new methods, e.g. one that returns a
+     * @implNote This is left public for now, so we can expose it with new methods, e.g., one that returns a
      * {@code Stream<FailedPollResult>}.
      */
     @SuppressWarnings("WeakerAccess")

--- a/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
@@ -450,7 +450,7 @@ class ClientPollerTest {
 
             @AfterEach
             void tearDown() {
-                // If current thread is interrupted, then reset the interrupted status by the following
+                // If the current thread is interrupted, then reset the interrupted status by the following
                 var result = Thread.interrupted();
                 if (result) {
                     LOG.info("Thread interrupted status cleared");
@@ -768,9 +768,9 @@ class ClientPollerTest {
         }
 
         /**
-         * @implNote To verify we don't let any exceptions escape in poll(), and because we have so much exception
-         * handling in ClientPoller already, had to pick something in executePoll() that we would not expect to ever
-         * fail and mock (actually, spy) it such that it actually does throw an exception. This test therefore verifies
+         * @implNote To verify that we don't let any exceptions escape in poll(), and because we have so much exception
+         * handling in ClientPoller already, we had to pick something in executePoll() that we would not expect to ever
+         * fail. So, we mock (actually, spy) it such that it actually does throw an exception. This test therefore verifies
          * that the poller continues to poll despite the exceptions that are being thrown after we've successfully handled
          * a poll response. An edge case to be sure, but we cannot allow exceptions to escape and cause the poller's
          * ScheduledExecutorService to terminate.

--- a/src/test/java/org/kiwiproject/dropwizard/poller/config/PollerHealthCheckConfigTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/config/PollerHealthCheckConfigTest.java
@@ -50,13 +50,12 @@ class PollerHealthCheckConfigTest {
             assertDefaultValues(softly);
         }
 
-    }
-
-    private void assertDefaultValues(SoftAssertions softly) {
-        softly.assertThat(config.getTimeWindow().toMinutes()).isEqualTo(15);
-        softly.assertThat(config.getFailedPollsThresholdPercent()).isEqualTo(2);
-        softly.assertThat(config.getAverageLatencyWarningThreshold().toMilliseconds()).isEqualTo(DEFAULT_AVG_LATENCY_WARNING_THRESHOLD_MILLIS);
-        softly.assertThat(config.getMissingPollMultiplier()).isEqualTo(10);
+        private void assertDefaultValues(SoftAssertions softly) {
+            softly.assertThat(config.getTimeWindow().toMinutes()).isEqualTo(15);
+            softly.assertThat(config.getFailedPollsThresholdPercent()).isEqualTo(2);
+            softly.assertThat(config.getAverageLatencyWarningThreshold().toMilliseconds()).isEqualTo(DEFAULT_AVG_LATENCY_WARNING_THRESHOLD_MILLIS);
+            softly.assertThat(config.getMissingPollMultiplier()).isEqualTo(10);
+        }
     }
 
     @Nested


### PR DESCRIPTION
* Remove deprecated API usage in ClientPollerMissedPollHealthCheck.
* Move private method assertDefaultValues inside the nested Builder class in PollerHealthCheckConfigTest, since it is only used by the tests in that nested class.
* Misc grammatical fixes in comments and Javadocs