### PR TITLE
Expose ClientPoller statistics via Dropwizard Metrics

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/poller/ClientPoller.java
+++ b/src/main/java/org/kiwiproject/dropwizard/poller/ClientPoller.java
@@ -10,6 +10,7 @@ import static org.kiwiproject.concurrent.Async.doAsync;
 import static org.kiwiproject.concurrent.Async.withMaxTimeout;
 import static org.kiwiproject.jaxrs.KiwiResponses.closeQuietly;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.core.setup.Environment;
 import jakarta.ws.rs.client.SyncInvoker;
@@ -22,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.kiwiproject.dropwizard.poller.config.PollerHealthCheckConfig;
 import org.kiwiproject.dropwizard.poller.health.ClientPollerHealthChecks;
+import org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics;
 import org.kiwiproject.dropwizard.poller.metrics.ClientPollerStatistics;
 import org.kiwiproject.dropwizard.poller.metrics.DefaultClientPollerStatistics;
 
@@ -244,6 +246,52 @@ public class ClientPoller {
      */
     public ClientPoller andRegisterHealthChecks(Environment environment, PollerHealthCheckConfig healthCheckConfig) {
         return registerHealthChecks(environment, healthCheckConfig);
+    }
+
+    /**
+     * Registers poller statistics as Dropwizard Metrics gauges using the given environment's {@link MetricRegistry}.
+     *
+     * @param environment the Dropwizard environment
+     * @return this poller
+     * @see ClientPollerMetrics#registerPollerMetrics(ClientPoller, Environment)
+     */
+    public ClientPoller registerMetrics(Environment environment) {
+        ClientPollerMetrics.registerPollerMetrics(this, environment);
+        return this;
+    }
+
+    /**
+     * Registers poller statistics as Dropwizard Metrics gauges into the given {@link MetricRegistry}.
+     *
+     * @param metricRegistry the metric registry
+     * @return this poller
+     * @see ClientPollerMetrics#registerPollerMetrics(ClientPoller, MetricRegistry)
+     */
+    public ClientPoller registerMetrics(MetricRegistry metricRegistry) {
+        ClientPollerMetrics.registerPollerMetrics(this, metricRegistry);
+        return this;
+    }
+
+    /**
+     * Named specifically to be used as part of the fluent builder API, e.g.
+     * {@code poller = ClientPoller.builder()...build().andRegisterMetrics(env);}
+     *
+     * @param environment the Dropwizard environment
+     * @return this poller
+     */
+    public ClientPoller andRegisterMetrics(Environment environment) {
+        return registerMetrics(environment);
+    }
+
+    /**
+     * Named specifically to be used as part of the fluent builder API, e.g.
+     * {@code poller = ClientPoller.builder()...build().andRegisterMetrics(metricRegistry);}
+     *
+     * @param metricRegistry the metric registry
+     * @return this poller
+     */
+    public ClientPoller andRegisterMetrics(MetricRegistry metricRegistry) {
+        return registerMetrics(metricRegistry);
     }
 
     /**

--- a/src/main/java/org/kiwiproject/dropwizard/poller/metrics/ClientPollerMetrics.java
+++ b/src/main/java/org/kiwiproject/dropwizard/poller/metrics/ClientPollerMetrics.java
@@ -33,6 +33,7 @@ public class ClientPollerMetrics {
      * @param poller   the poller whose statistics to expose
      * @param registry the metric registry
      * @return the list of registered metric names
+     * @throws IllegalArgumentException if any of the metric names are already registered
      */
     public static List<String> registerPollerMetrics(ClientPoller poller, MetricRegistry registry) {
         var stats = poller.statistics();

--- a/src/main/java/org/kiwiproject/dropwizard/poller/metrics/ClientPollerMetrics.java
+++ b/src/main/java/org/kiwiproject/dropwizard/poller/metrics/ClientPollerMetrics.java
@@ -1,0 +1,67 @@
+package org.kiwiproject.dropwizard.poller.metrics;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.core.setup.Environment;
+import lombok.experimental.UtilityClass;
+import org.kiwiproject.dropwizard.poller.ClientPoller;
+
+import java.util.List;
+
+/**
+ * Utility class for registering {@link ClientPoller} statistics as Dropwizard Metrics gauges,
+ * making them available via the standard metrics endpoint and any configured metrics reporter.
+ */
+@UtilityClass
+public class ClientPollerMetrics {
+
+    /**
+     * Registers gauges for all standard {@link ClientPollerStatistics} fields into the given Dropwizard environment's
+     * {@link MetricRegistry}.
+     *
+     * @param poller      the poller whose statistics to expose
+     * @param environment the Dropwizard environment
+     * @return the list of registered metric names
+     */
+    public static List<String> registerPollerMetrics(ClientPoller poller, Environment environment) {
+        return registerPollerMetrics(poller, environment.metrics());
+    }
+
+    /**
+     * Registers gauges for all standard {@link ClientPollerStatistics} fields into the given {@link MetricRegistry}.
+     *
+     * @param poller   the poller whose statistics to expose
+     * @param registry the metric registry
+     * @return the list of registered metric names
+     */
+    public static List<String> registerPollerMetrics(ClientPoller poller, MetricRegistry registry) {
+        var stats = poller.statistics();
+        var name = poller.getName();
+
+        var countName = metricName(name, "count");
+        var successCountName = metricName(name, "success-count");
+        var failureCountName = metricName(name, "failure-count");
+        var skipCountName = metricName(name, "skip-count");
+        var avgLatencyName = metricName(name, "average-poll-latency-ms");
+
+        registry.register(countName, (Gauge<Integer>) stats::totalCount);
+        registry.register(successCountName, (Gauge<Integer>) stats::successCount);
+        registry.register(failureCountName, (Gauge<Integer>) stats::failureCount);
+        registry.register(skipCountName, (Gauge<Integer>) stats::skipCount);
+        registry.register(avgLatencyName, (Gauge<Double>) stats::averagePollLatencyInMillis);
+
+        return List.of(countName, successCountName, failureCountName, skipCountName, avgLatencyName);
+    }
+
+    /**
+     * Returns the metric name for the given poller name and metric suffix, using the standard
+     * {@code ClientPoller.<pollerName>.<suffix>} naming convention.
+     *
+     * @param pollerName   the name of the poller
+     * @param metricSuffix the metric suffix (e.g. {@code "count"}, {@code "success-count"})
+     * @return the full metric name
+     */
+    public static String metricName(String pollerName, String metricSuffix) {
+        return MetricRegistry.name("ClientPoller", pollerName, metricSuffix);
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.dropwizard.poller;
 
 import static java.util.Objects.nonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
@@ -20,6 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import io.dropwizard.core.setup.Environment;
 import jakarta.ws.rs.ProcessingException;
@@ -634,7 +636,7 @@ class ClientPollerTest {
         @Test
         void testRegisterMetrics_UsingFluentApiMethod_AndRegisterMetrics_WithEnvironment() {
             var env = mock(Environment.class);
-            var registry = new com.codahale.metrics.MetricRegistry();
+            var registry = new MetricRegistry();
 
             when(env.metrics()).thenReturn(registry);
 
@@ -643,27 +645,27 @@ class ClientPollerTest {
             assertThat(pollerWithMetrics).isSameAs(poller);
 
             assertThat(registry.getGauges())
-                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "count"))
-                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "success-count"))
-                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "failure-count"))
-                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "skip-count"))
-                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "average-poll-latency-ms"));
+                    .containsKey(metricName(poller.getName(),"count"))
+                    .containsKey(metricName(poller.getName(),"success-count"))
+                    .containsKey(metricName(poller.getName(),"failure-count"))
+                    .containsKey(metricName(poller.getName(),"skip-count"))
+                    .containsKey(metricName(poller.getName(),"average-poll-latency-ms"));
         }
 
         @Test
         void testRegisterMetrics_UsingFluentApiMethod_AndRegisterMetrics_WithMetricRegistry() {
-            var registry = new com.codahale.metrics.MetricRegistry();
+            var registry = new MetricRegistry();
 
             var pollerWithMetrics = poller.andRegisterMetrics(registry);
 
             assertThat(pollerWithMetrics).isSameAs(poller);
 
             assertThat(registry.getGauges())
-                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "count"))
-                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "success-count"))
-                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "failure-count"))
-                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "skip-count"))
-                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "average-poll-latency-ms"));
+                    .containsKey(metricName(poller.getName(),"count"))
+                    .containsKey(metricName(poller.getName(),"success-count"))
+                    .containsKey(metricName(poller.getName(),"failure-count"))
+                    .containsKey(metricName(poller.getName(),"skip-count"))
+                    .containsKey(metricName(poller.getName(),"average-poll-latency-ms"));
         }
 
         @Test

--- a/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
@@ -632,6 +632,43 @@ class ClientPollerTest {
         }
 
         @Test
+        void testRegisterMetrics_UsingFluentApiMethod_AndRegisterMetrics_WithEnvironment() {
+            var env = mock(Environment.class);
+            var registry = new com.codahale.metrics.MetricRegistry();
+
+            when(env.metrics()).thenReturn(registry);
+
+            var pollerWithMetrics = poller.andRegisterMetrics(env);
+
+            assertThat(pollerWithMetrics).isSameAs(poller);
+
+            assertThat(registry.getGauges().keySet()).contains(
+                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "count"),
+                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "success-count"),
+                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "failure-count"),
+                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "skip-count"),
+                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "average-poll-latency-ms")
+            );
+        }
+
+        @Test
+        void testRegisterMetrics_UsingFluentApiMethod_AndRegisterMetrics_WithMetricRegistry() {
+            var registry = new com.codahale.metrics.MetricRegistry();
+
+            var pollerWithMetrics = poller.andRegisterMetrics(registry);
+
+            assertThat(pollerWithMetrics).isSameAs(poller);
+
+            assertThat(registry.getGauges().keySet()).contains(
+                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "count"),
+                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "success-count"),
+                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "failure-count"),
+                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "skip-count"),
+                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "average-poll-latency-ms")
+            );
+        }
+
+        @Test
         void testCannotStart_UnlessExecutionIntervalIsPositive() {
             var illegalExecutionIntervalPoller = ClientPoller.builder()
                     .supplier(() -> invoker)

--- a/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/ClientPollerTest.java
@@ -642,13 +642,12 @@ class ClientPollerTest {
 
             assertThat(pollerWithMetrics).isSameAs(poller);
 
-            assertThat(registry.getGauges().keySet()).contains(
-                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "count"),
-                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "success-count"),
-                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "failure-count"),
-                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "skip-count"),
-                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "average-poll-latency-ms")
-            );
+            assertThat(registry.getGauges())
+                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "count"))
+                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "success-count"))
+                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "failure-count"))
+                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "skip-count"))
+                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "average-poll-latency-ms"));
         }
 
         @Test
@@ -659,13 +658,12 @@ class ClientPollerTest {
 
             assertThat(pollerWithMetrics).isSameAs(poller);
 
-            assertThat(registry.getGauges().keySet()).contains(
-                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "count"),
-                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "success-count"),
-                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "failure-count"),
-                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "skip-count"),
-                    org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "average-poll-latency-ms")
-            );
+            assertThat(registry.getGauges())
+                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "count"))
+                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "success-count"))
+                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "failure-count"))
+                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "skip-count"))
+                    .containsKey(org.kiwiproject.dropwizard.poller.metrics.ClientPollerMetrics.metricName(poller.getName(), "average-poll-latency-ms"));
         }
 
         @Test

--- a/src/test/java/org/kiwiproject/dropwizard/poller/metrics/ClientPollerMetricsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/metrics/ClientPollerMetricsTest.java
@@ -1,0 +1,114 @@
+package org.kiwiproject.dropwizard.poller.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.core.setup.Environment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.dropwizard.poller.ClientPoller;
+
+import java.util.concurrent.Executors;
+
+@DisplayName("ClientPollerMetrics")
+class ClientPollerMetricsTest {
+
+    private ClientPoller poller;
+    private MetricRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        poller = ClientPoller.builder()
+                .name("TestPoller")
+                .supplier(() -> mock(jakarta.ws.rs.client.SyncInvoker.class))
+                .consumer(response -> {})
+                .executor(Executors.newSingleThreadScheduledExecutor())
+                .executionInterval(1000)
+                .build();
+
+        registry = new MetricRegistry();
+    }
+
+    @Nested
+    class MetricName {
+
+        @Test
+        void shouldBuildNameFromPollerNameAndSuffix() {
+            assertThat(ClientPollerMetrics.metricName("MyPoller", "count"))
+                    .isEqualTo("ClientPoller.MyPoller.count");
+        }
+
+        @Test
+        void shouldBuildNameWithHyphenatedSuffix() {
+            assertThat(ClientPollerMetrics.metricName("MyPoller", "success-count"))
+                    .isEqualTo("ClientPoller.MyPoller.success-count");
+        }
+    }
+
+    @Nested
+    class RegisterPollerMetrics {
+
+        @Test
+        void shouldRegisterAllGaugesWithMetricRegistry() {
+            var registeredNames = ClientPollerMetrics.registerPollerMetrics(poller, registry);
+
+            assertThat(registeredNames).containsExactlyInAnyOrder(
+                    "ClientPoller.TestPoller.count",
+                    "ClientPoller.TestPoller.success-count",
+                    "ClientPoller.TestPoller.failure-count",
+                    "ClientPoller.TestPoller.skip-count",
+                    "ClientPoller.TestPoller.average-poll-latency-ms"
+            );
+
+            assertThat(registry.getGauges()).containsOnlyKeys(
+                    "ClientPoller.TestPoller.count",
+                    "ClientPoller.TestPoller.success-count",
+                    "ClientPoller.TestPoller.failure-count",
+                    "ClientPoller.TestPoller.skip-count",
+                    "ClientPoller.TestPoller.average-poll-latency-ms"
+            );
+        }
+
+        @Test
+        void shouldRegisterAllGaugesWithEnvironment() {
+            var env = mock(Environment.class);
+            when(env.metrics()).thenReturn(registry);
+
+            ClientPollerMetrics.registerPollerMetrics(poller, env);
+
+            assertThat(registry.getGauges()).containsOnlyKeys(
+                    "ClientPoller.TestPoller.count",
+                    "ClientPoller.TestPoller.success-count",
+                    "ClientPoller.TestPoller.failure-count",
+                    "ClientPoller.TestPoller.skip-count",
+                    "ClientPoller.TestPoller.average-poll-latency-ms"
+            );
+        }
+
+        @Test
+        void shouldReflectCurrentStatisticsValues() {
+            ClientPollerMetrics.registerPollerMetrics(poller, registry);
+
+            var stats = poller.statistics();
+            stats.incrementCount();
+            stats.incrementSuccessCount();
+            stats.incrementSuccessCount();
+            stats.incrementFailureCount("error");
+            stats.incrementSkipCount();
+            stats.addPollLatencyMeasurement(100);
+
+            var gauges = registry.getGauges();
+
+            assertThat((Gauge<Integer>) gauges.get("ClientPoller.TestPoller.count")).extracting(Gauge::getValue).isEqualTo(1);
+            assertThat((Gauge<Integer>) gauges.get("ClientPoller.TestPoller.success-count")).extracting(Gauge::getValue).isEqualTo(2);
+            assertThat((Gauge<Integer>) gauges.get("ClientPoller.TestPoller.failure-count")).extracting(Gauge::getValue).isEqualTo(1);
+            assertThat((Gauge<Integer>) gauges.get("ClientPoller.TestPoller.skip-count")).extracting(Gauge::getValue).isEqualTo(1);
+            assertThat((Gauge<Double>) gauges.get("ClientPoller.TestPoller.average-poll-latency-ms")).extracting(Gauge::getValue).isEqualTo(100.0);
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/poller/metrics/ClientPollerMetricsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/poller/metrics/ClientPollerMetricsTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.core.setup.Environment;
+import jakarta.ws.rs.client.SyncInvoker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -25,7 +26,7 @@ class ClientPollerMetricsTest {
     void setUp() {
         poller = ClientPoller.builder()
                 .name("TestPoller")
-                .supplier(() -> mock(jakarta.ws.rs.client.SyncInvoker.class))
+                .supplier(() -> mock(SyncInvoker.class))
                 .consumer(response -> {})
                 .executor(Executors.newSingleThreadScheduledExecutor())
                 .executionInterval(1000)


### PR DESCRIPTION
Adds ClientPollerMetrics utility class that registers ClientPollerStatistics fields as Dropwizard Metrics gauges (count, success-count, failure-count, skip-count, average-poll-latency-ms), making them available via the standard /metrics admin endpoint and any configured metrics reporter.

Adds registerMetrics and andRegisterMetrics methods to ClientPoller accepting either a Dropwizard Environment or a MetricRegistry directly, mirroring the existing health check API. Purely additive - no existing API is modified.

Background in discussion #54

Closes #354